### PR TITLE
handle multiple `_` in a row for cards command

### DIFF
--- a/bosibot.py
+++ b/bosibot.py
@@ -109,9 +109,9 @@ if __name__ == '__main__':
 
                 card = " ".join(card)
 
-            return match.group(1) + card + match.group(3)
+            return match.group(1) + card
 
-        text = re.sub('(^|\W)(_+)($|\W)', replace_underscore_with_card, text[1:])
+        text = re.sub('(^|\W)(_+)(?=$|\W)', replace_underscore_with_card, text[1:])
 
         while len(text) > 350:
             irc_send("", text[:text.index(" ", 350)])


### PR DESCRIPTION
When the input was `_ _ _` the regular expression only
was able to match the first and last underscore.  This is
because the pattern overlapped and the regex won't match
overlapping patterns.

instead, we use a lookahead for the third matching group,
making it unmatching, and correctly match the inputs